### PR TITLE
Fix gradle test failure

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -75,3 +75,7 @@ dependencies {
 	compile "org.jetbrains.kotlin:kotlin-reflect"
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 }
+
+springBoot {
+	mainClass = 'com.worksap.assetwizard.AssetWizardApplication'
+}

--- a/backend/src/main/kotlin/com/worksap/assetwizard/AssetWizardApplication.kt
+++ b/backend/src/main/kotlin/com/worksap/assetwizard/AssetWizardApplication.kt
@@ -1,18 +1,13 @@
 package com.worksap.assetwizard
 
 import org.springframework.boot.SpringApplication
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.Configuration
-import org.springframework.web.servlet.config.annotation.EnableWebMvc
+import org.springframework.boot.autoconfigure.SpringBootApplication
 
-
-// Entry point
-@EnableAutoConfiguration
-@Configuration
-@ComponentScan("com.worksap.assetwizard.controller, com.worksap.assetwizard.service, com.worksap.assetwizard.Repository")
-class AssetWizardApplication
-
-fun main(args: Array<String>) {
-    SpringApplication.run(AssetWizardApplication::class.java, *args)
+@SpringBootApplication
+class AssetWizardApplication {
+    companion object {
+        @JvmStatic fun main(args: Array<String>) {
+            SpringApplication.run(AssetWizardApplication::class.java, *args)
+        }
+    }
 }


### PR DESCRIPTION
Currently `./gradlew test` fails by following error:

> java.lang.IllegalStateException: Unable to find a @SpringBootConfiguration, you need to use @ContextConfiguration or @SpringBootTest(classes=...) with your test

According to [official document](https://spring.io/guides/gs/spring-boot/), SpringBootApplication annotation can replace Configuration, EnableWebMvc and ComponentScan. Then we can replace existing annotations by single `@SpringBootConfiguration` that fulfill requirements from `spring-boot-starter-test`.

I also add `mainClass` into `build.gradle`, that enables `./gradlew bootRun`.

Note: [`runApplication()` is recommended way](https://spring.io/guides/tutorials/spring-boot-kotlin/#_understanding_the_generated_project), but it is not supported in Spring Boot v1.